### PR TITLE
docs: mention Zoo Code as the Roo Code community successor

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 # 🚀 OpenAnalyst
 
-> Open-source VS Code AI agent specialized in **data analytics** and general coding related tasks. Merged features from [KiloCode](https://github.com/Kilo-Org/kilocode), [Roo Code](https://github.com/RooVetGit/Roo-Code), and [Cline](https://github.com/cline/cline).
+> Open-source VS Code AI agent specialized in **data analytics** and general coding related tasks. Merged features from [KiloCode](https://github.com/Kilo-Org/kilocode), [Roo Code](https://github.com/RooVetGit/Roo-Code) (continued by [Zoo Code](https://github.com/Zoo-Code-Org/Zoo-Code/)), and [Cline](https://github.com/cline/cline).
 
 - ✨ Generate code from natural language
 - 📊 **Data Analytics Mode** - Specialized AI assistance for data analytics tasks


### PR DESCRIPTION
Roo Code (`RooCodeInc/Roo-Code`) was archived / shut down on May 15, 2026 and is now
read-only. Its own repo notes the community successor here:
https://github.com/RooCodeInc/Roo-Code#disclaimer

Zoo Code is the community-maintained fork that continues where Roo Code left off:
- Site: https://zoocode.dev/
- Source: https://github.com/Zoo-Code-Org/Zoo-Code/

This PR adds a Zoo Code reference alongside the existing Roo Code mention in the README so
readers looking for a maintained alternative can find it.
